### PR TITLE
added pick-type being a more efficient solution than or

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,23 +94,25 @@ Notice:
 | `(string+)`                                 | expects a string                       |
 | `(tuple+ [(number+) (string+) (boolean+)])` | expects items of exact rules and order |
 | `(vector+ (boolean+))`                      | expects a vector of items              |
+| `(pick-type+ {:a (record+ {:type :a})})`    | expects branches picked by type        |
 
 Some rules got options for extending abilities:
 
-| Rule      | Option                  | Meaning                                   |
-| --------- | ----------------------- | ----------------------------------------- |
-| `any+`    | `{:some? true}`         | stop accepting `nil`s                     |
-| `list+`   | `{:allow-seq? true}`    | accepts list in a lazy sequence           |
-| `number+` | `{:min 0}`              | min value                                 |
-|           | `{:max 10}`             | max value                                 |
-| `record+` | `{:all-optional? true}` | mark all fields as not required           |
-|           | `{:check-keys? true}`   | check keys in record obeys rules, no more |
-|           | `{:exact-keys? true}`   | check all keys, no more no fewer          |
-| `string+` | `{:nonblank? true}`     | stop accepting blank strings              |
-|           | `{:re #"\\d"}`          | regex for testing string                  |
-| `tuple+`  | `{:in-list? true}`      | accepts list as input                     |
-|           | `{:check-size? true}`   | check if size exactly the same            |
-| `vector+` | `{:allow-seq? true}`    | accepts lazy sequences as well            |
+| Rule         | Option                  | Meaning                                   |
+| ------------ | ----------------------- | ----------------------------------------- |
+| `any+`       | `{:some? true}`         | stop accepting `nil`s                     |
+| `list+`      | `{:allow-seq? true}`    | accepts list in a lazy sequence           |
+| `number+`    | `{:min 0}`              | min value                                 |
+|              | `{:max 10}`             | max value                                 |
+| `record+`    | `{:all-optional? true}` | mark all fields as not required           |
+|              | `{:check-keys? true}`   | check keys in record obeys rules, no more |
+|              | `{:exact-keys? true}`   | check all keys, no more no fewer          |
+| `string+`    | `{:nonblank? true}`     | stop accepting blank strings              |
+|              | `{:re #"\\d"}`          | regex for testing string                  |
+| `tuple+`     | `{:in-list? true}`      | accepts list as input                     |
+|              | `{:check-size? true}`   | check if size exactly the same            |
+| `vector+`    | `{:allow-seq? true}`    | accepts lazy sequences as well            |
+| `pick-type+` | `{:type-field :type}`   | specify a field for telling type          |
 
 #### Recursive data
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1101,6 +1101,11 @@
                       |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1579592714911) (:text |:keyword) (:id |lNPL7i7kTleaf)
                       |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1579592718583) (:text |validate-keyword) (:id |G6K9P1dX)
                     :id |lNPL7i7kT
+                  |yyyy $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615799593)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615801490) (:text |:pick-type) (:id |Tph0Ji18Qeleaf)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615805268) (:text |validate-pick-type) (:id |eEEdSIK_oZ)
+                    :id |Tph0Ji18Qe
                   |yyyv $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1581561641303)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1581561642436) (:text |:any) (:id |5ptfczd8leaf)
@@ -4473,6 +4478,208 @@
                     :id |R1iDyUDLj
                 :id |fvo_FZam5
             :id |O4Xz75k8v
+          |validate-pick-type $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615346096)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615346096) (:text |defn) (:id |vu69dTce_L)
+              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615346096) (:text |validate-pick-type) (:id |xXGUAz9oW9)
+              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615346096)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615357916) (:text |data) (:id |u1Sllbm_Bu)
+                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615360142) (:text |rule) (:id |my1Nx-Y4Bf)
+                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615360866) (:text |coord) (:id |wC2cVgu4VM)
+                :id |V7iAsZKSw4
+              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615366739)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615366739) (:text |let) (:id |cDyddzlsaB)
+                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615366739)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615366739)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615368792) (:text |dict) (:id |ljqa3AYMiL)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615366739)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615370372) (:text |:dict) (:id |OSziZPJdNF)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615366739) (:text |rule) (:id |jcfpF8EvF4)
+                            :id |QDQxLCuSae
+                        :id |0Z6WuGesIu
+                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615366739)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615366739) (:text |next-coord) (:id |74_m929U4K)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615366739)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615366739) (:text |conj) (:id |kLg6wmAkfg)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615366739) (:text |coord) (:id |dtu40QTXrc)
+                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615374812) (:text |'pick-type) (:id |nXFha5mNE5K)
+                            :id |Z__ivVzHEr
+                        :id |TxCHpc-n5A
+                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615441718)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615444506) (:text |type-field) (:id |IMCpDhro5vleaf)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615444858)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615446967) (:text |:type-field) (:id |uskd6utLFL)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615457684) (:text |rule) (:id |l5pc6WplI)
+                            :id |6iePGV0Fvv
+                        :id |IMCpDhro5v
+                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615492006)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615496433) (:text |data-type) (:id |pN9i37xFo4leaf)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615500963)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615500963) (:text |get) (:id |AoqPgpmSeP)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615500963) (:text |data) (:id |I_aZ0Fxtzo)
+                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615500963) (:text |type-field) (:id |l3UJJf8Z1Z)
+                            :id |As4wjltBzx
+                        :id |pN9i37xFo4
+                    :id |riYBadkfCv
+                  |l $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615505411)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615505829) (:text |if) (:id |QyGMiSlJHBleaf)
+                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615506038)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615506658) (:text |nil?) (:id |VJ1MM9iygm)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615508922)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615507394) (:text |data-type) (:id |KMXqipVIBT)
+                              |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615509689) (:text |get) (:id |ksGsQjK1P)
+                              |L $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615510386) (:text |dict) (:id |oIZWY_CebD)
+                            :id |u0SUu3PSM
+                        :id |EARiAg0m3l
+                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615514343)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |{}) (:id |RgwPQuF9q_)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615514343)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |:ok?) (:id |ybGAPqGGVw)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |false) (:id |Ka2KiUgXwB)
+                            :id |LTcQtHrQgh
+                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615514343)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |:coord) (:id |ulm0632pYu)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |next-coord) (:id |vFMcqmkOKv)
+                            :id |jJqfN49CpC
+                          |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615514343)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |:rule) (:id |Owfga2PwIQ)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |rule) (:id |RDqWAZHqQ6)
+                            :id |its-LPWC0N
+                          |x $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615514343)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |:data) (:id |2c9GP2NEVW)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |data) (:id |pLLRsKtUY1)
+                            :id |_8oTd1uhRl
+                          |y $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615514343)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |:message) (:id |RobVNYOALmv)
+                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615514343)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |get-in) (:id |ao5C8961SQP)
+                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |rule) (:id |T4b-HQuvOB9)
+                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615514343)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |[]) (:id |-PtmnQQfmwf)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |:options) (:id |daWIGXW8yhF)
+                                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615514343) (:text |:message) (:id |GWZLhssDUje)
+                                    :id |winjFUhoLwO
+                                  |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615535975)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615538894) (:text "|\"found no matched type in pick-type: ") (:id |pKmiSF5Zdct)
+                                      |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615536904) (:text |str) (:id |X16VzGuKs)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615543605) (:text |data-type) (:id |cPEzNNa7FP)
+                                    :id |fBtKxClkHK
+                                :id |PO8POFM9ye3
+                            :id |GF1E855bEYP
+                        :id |3kgwSwQsCm
+                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615568535)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615569497) (:text |let) (:id |BHdJeDh89leaf)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615569972)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615570183)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615620622) (:text |next-rule) (:id |3HDvMWVs6t)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615616289)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615616289) (:text |get) (:id |_RGHJpTVqS)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615616289) (:text |dict) (:id |_QSV4IWRLo)
+                                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615616289) (:text |data-type) (:id |EIfrJA9uGD)
+                                    :id |devjWw84lx
+                                :id |pWPSjut94
+                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615645016)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615646687) (:text |result) (:id |Neo6qxxF-Cleaf)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615646945)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615654552) (:text |validate-lilac) (:id |QYSJJiAEEv)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615657314) (:text |data) (:id |4L7n4Rggt)
+                                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615660356) (:text |next-rule) (:id |eoPokFPBTD)
+                                      |v $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615662128) (:text |next-coord) (:id |6EATveMCjU)
+                                    :id |d27k6lYzXJ
+                                :id |Neo6qxxF-C
+                            :id |nfd35rYvjy
+                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615663379)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615664347) (:text |if) (:id |tcmQsXx45leaf)
+                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615664900)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615667442) (:text |:ok?) (:id |UhDY9exNBO)
+                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615668619) (:text |result) (:id |O3N3zDcZJL)
+                                :id |HjdZQdHRpx
+                              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615719715)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615720294) (:text |{}) (:id |-VSpapX25Cleaf)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615720906)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615721972) (:text |:ok?) (:id |IYLW7gy0YT)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615723010) (:text |false) (:id |0vCkLurOC)
+                                    :id |aSvATX40vv
+                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615723397)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615725212) (:text |:coord) (:id |-T4Tg-iZhWleaf)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615727241) (:text |next-coord) (:id |orlKjpg0cf)
+                                    :id |-T4Tg-iZhW
+                                  |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615727766)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615728922) (:text |:rule) (:id |UHtflCsU9xleaf)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615730892) (:text |rule) (:id |88sNjGs7-5)
+                                    :id |UHtflCsU9x
+                                  |x $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615731386)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615732561) (:text |:data) (:id |nSnG3ORTZ_leaf)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615733905) (:text |data) (:id |DufcPZeWab)
+                                    :id |nSnG3ORTZ_
+                                  |y $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615736196)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615738043) (:text |:message) (:id |MJKxVPtjvleaf)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615744987)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615744987) (:text |get-in) (:id |iz_3gHzW9H)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615744987) (:text |rule) (:id |meLRIlR-R8)
+                                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615744987)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615744987) (:text |[]) (:id |uE5hzD_tul)
+                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615744987) (:text |:options) (:id |SzO9yDmVd7)
+                                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615744987) (:text |:message) (:id |cG0S7TPHZG)
+                                            :id |3YiGg5FS2Z
+                                          |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615744987)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615744987) (:text |str) (:id |KiQNANNud_)
+                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615761417) (:text "|\"failed to match in pick-type") (:id |6OOX6JHqqW)
+                                            :id |MV0JtOTRTD
+                                        :id |661tEF6QAl
+                                    :id |MJKxVPtjv
+                                  |yT $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615763631)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615765132) (:text |:next) (:id |Y5a_FXFPFQleaf)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615768918) (:text |result) (:id |RhJ6ghpdIp)
+                                    :id |Y5a_FXFPFQ
+                                :id |-VSpapX25C
+                              |p $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615780279) (:text |result) (:id |i_3AmSJ6G3)
+                            :id |tcmQsXx45
+                        :id |BHdJeDh89
+                    :id |QyGMiSlJHB
+                :id |RSPj3U7nHw
+            :id |5KbH_yLBMl
           |validate-custom $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1579592588441)
             :data $ {}
               |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1579592588441) (:text |defn) (:id |OMND_77HI)
@@ -4580,6 +4787,76 @@
                     :id |y2K0-mYzq
                 :id |iOfBT0Rh
             :id |ehiutdbYG
+          |pick-type+ $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615156664)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615164770) (:text |defn$) (:id |x175kc4NEs)
+              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615156664) (:text |pick-type+) (:id |DXJlCcIyCv)
+              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615166183)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615156664)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615174493) (:text |dict) (:id |CCExodZigS)
+                    :id |DwEMck4JCL
+                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615178952)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615184667) (:text |pick-type+) (:id |2ToHem3bEg)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615186888) (:text |dict) (:id |46hyFj-c-)
+                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615201050) (:text |nil) (:id |kevWcNZq0T)
+                    :id |gDUhdc4AiF
+                :id |s6wRO0c4a
+              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615166183)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615156664)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615174493) (:text |dict) (:id |CCExodZigS)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615206201) (:text |options) (:id |zqWaLi3E4b)
+                    :id |DwEMck4JCL
+                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615262063)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615262063) (:text |{}) (:id |Cy4TLA13zI)
+                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615262063)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615262063) (:text |:lilac-type) (:id |2I2p1akQKQ)
+                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615267997) (:text |:pick-type) (:id |kuA0BIqfCT)
+                        :id |SdwoObC9-1
+                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615262063)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615270444) (:text |:dict) (:id |KhskPaj99O)
+                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615271973) (:text |dict) (:id |hwj_iV_lTs)
+                        :id |owkMskjLdX
+                      |y $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615262063)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615294612) (:text |:type-field) (:id |28ibGrh6ZX2)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615303421)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615262063)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615303048) (:text |:type-field) (:id |a3m9Gbk7Hz_)
+                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615262063) (:text |options) (:id |H_ni0Cy3iVz)
+                                :id |-b8IiHw27Vq
+                              |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615305000) (:text |or) (:id |bpCtTEdYHo)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615306884) (:text |:type) (:id |Wy900BbUL1)
+                            :id |K-Lqg4CFhr
+                        :id |-gu1Y5EurLZ
+                      |u $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615285776)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615285776) (:text |:options) (:id |hsNlmPyRUJ)
+                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615285776) (:text |options) (:id |el6ySfvJh4)
+                        :id |1NuljhwWL1
+                    :id |npbVaoYwg-
+                  |b $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615233976)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615233976) (:text |check-keys) (:id |i8slnpZu8j)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615240023) (:text "|\"checking pick-type+") (:id |XkRafW55zm)
+                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615233976) (:text |options) (:id |nh4QZXR1mL)
+                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615233976)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615233976) (:text |[]) (:id |_WXIHX5vBs)
+                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615247457) (:text |:type-field) (:id |kGIHuh6Dq2)
+                        :id |7XM9YLRkYJ
+                    :id |aR04BcAdBv
+                :id |1mTSJ_pQp
+            :id |VZLOWziP7h
           |validate-any $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1581561422257)
             :data $ {}
               |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1581561422257) (:text |defn) (:id |pvh7XDHpb)
@@ -5980,6 +6257,7 @@
                         |yr $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1580376057851) (:text |custom+) (:id |sv4ANrrWL)
                         |yyyT $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1580377231980) (:text |register-custom-rule!) (:id |YWMdwhDsS)
                         |yT $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1580376057851) (:text |number+) (:id |MVh0XreFW)
+                        |yyyD $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615879794) (:text |pick-type+) (:id |JFBLM6QHq)
                         |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1580376057851) (:text |validate-lilac) (:id |g7IxnUseM)
                         |x $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1580376057851) (:text |keyword+) (:id |oUMr_oMGq)
                         |v $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1580376057851) (:text |optional+) (:id |_WU2W6O8B)
@@ -9101,6 +9379,355 @@
                     :id |fPwBoVvHl
                 :id |CG7po_N4w
             :id |CqJDOqfS8
+          |test-pick-type $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615816330)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615827739) (:text |deftest) (:id |WYEIyedEqf)
+              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615816330) (:text |test-pick-type) (:id |noTQg-a2j0)
+              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615997956)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615816330)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615836811) (:text |testing) (:id |4kVWDqnDO)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616076654) (:text "|\"pick-type of a") (:id |bIQD9mLv8d)
+                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615851714)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |is) (:id |kUJVUuAkfp)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615851714)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |=ok) (:id |xc-kwIfaXg)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |true) (:id |WdEV3mRaM4)
+                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615851714)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |validate-lilac) (:id |DrgbxyRkPM)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615856809)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615857162) (:text |{}) (:id |t0udBfmoPX)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615857487)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615862108) (:text |:type) (:id |TiFVRm8t6a)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615862983) (:text |:a) (:id |-T6-aiKT7K)
+                                        :id |3tvj2eKbVC
+                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615863608)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615864658) (:text |:name) (:id |s9LRsf38m3leaf)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615867969) (:text "|\"a") (:id |Ya67Ut-Tc)
+                                        :id |s9LRsf38m3
+                                    :id |zXEIEPwG2S
+                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616012768) (:text |a-or-b) (:id |HGSBH3TDDH)
+                                :id |vhgCXEwNsp
+                            :id |ckNRzsfA_s
+                        :id |EXOQeBlAIq
+                    :id |FKxCWoKVvP
+                  |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615998727) (:text |let) (:id |QJQkKkmuk)
+                  |L $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615998892)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615999049)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616007961) (:text |a-or-b) (:id |0yc5qMfvFH)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |pick-type+) (:id |O-NCQWy1sG)
+                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |{}) (:id |qVa7AOwvTo)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |:a) (:id |fo858_bwQI)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |record+) (:id |OMIuqMfE6i)
+                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |{}) (:id |CxtwRW9u9T)
+                                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |:type) (:id |-5EgfeunCn)
+                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |is+) (:id |qnn3OhvzIJ)
+                                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |:a) (:id |CKjm3pxeka)
+                                                    :id |xFMy3ijIzV
+                                                :id |8_9P3PHt28
+                                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |:name) (:id |F2hM_PSDb99)
+                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |string+) (:id |iz022SdjIWe)
+                                                    :id |ev63W_f7MSv
+                                                :id |9k39vOcMz_e
+                                            :id |iHN2Z5hZn0
+                                        :id |js4uLkkW5I
+                                    :id |wvybqCCmZD
+                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |:b) (:id |E6i84yfYs0q)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |record+) (:id |3e16i72N7E4)
+                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |{}) (:id |GOwO_RFQK51)
+                                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |:type) (:id |uF8iDLl--uQ)
+                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616003252) (:text |is+) (:id |T3GEJD-Z4b5)
+                                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616110527) (:text |:b) (:id |ZtxmBRuwWVA)
+                                                    :id |Su1OLX5aRo3
+                                                :id |ctrJCIsHz7b
+                                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616003252)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616021510) (:text |:size) (:id |5xPuXoOiuD8)
+                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616021774)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616022806) (:text |number+) (:id |gBkxnz6P3Q)
+                                                    :id |AUtl7AhECn
+                                                :id |gIluQWBoq6O
+                                            :id |gbckWxCaVJH
+                                        :id |-C1_4SVR3AN
+                                    :id |bI9oV3hnmmj
+                                :id |JP5NPRzonF
+                            :id |1--q1uqqqt
+                        :id |sgS6bT5USN
+                    :id |MEBOUhvC_U
+                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615816330)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615836811) (:text |testing) (:id |4kVWDqnDO)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616079000) (:text "|\"pick-type of b") (:id |bIQD9mLv8d)
+                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615851714)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |is) (:id |kUJVUuAkfp)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615851714)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |=ok) (:id |xc-kwIfaXg)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |true) (:id |WdEV3mRaM4)
+                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615851714)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |validate-lilac) (:id |DrgbxyRkPM)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615856809)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615857162) (:text |{}) (:id |t0udBfmoPX)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615857487)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615862108) (:text |:type) (:id |TiFVRm8t6a)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616029674) (:text |:b) (:id |-T6-aiKT7K)
+                                        :id |3tvj2eKbVC
+                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615863608)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616356744) (:text |:size) (:id |s9LRsf38m3leaf)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616033160) (:text |1) (:id |Ya67Ut-Tc)
+                                        :id |s9LRsf38m3
+                                    :id |zXEIEPwG2S
+                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616012768) (:text |a-or-b) (:id |HGSBH3TDDH)
+                                :id |vhgCXEwNsp
+                            :id |ckNRzsfA_s
+                        :id |EXOQeBlAIq
+                    :id |0jRmmzqJgB
+                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616048515)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text |testing) (:id |R5ktidmSim)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616092440) (:text "|\"pick-type fail b") (:id |9D71ptgSqB)
+                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616048515)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text |is) (:id |GeVy_N6pPL)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616048515)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text |=ok) (:id |KS3qOgssKl)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text |false) (:id |P9wLcdan3X)
+                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616048515)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text |validate-lilac) (:id |STnMBxNuXJ)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616048515)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text |{}) (:id |IDURw9CNdE)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616048515)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text |:type) (:id |yFi8I3uMTe)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text |:b) (:id |g19abYy9g-s)
+                                        :id |A19QEykaWh
+                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616048515)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text |:name) (:id |AUN_iBnK0GF)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616048515) (:text "|\"a") (:id |kdipCgl_PM5)
+                                        :id |VJZl7EA9hHI
+                                    :id |znHhoXQWsk
+                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616054147) (:text |a-or-b) (:id |3YpKbgcVvm)
+                                :id |LjUB1SsPHl
+                            :id |4ddPfdhq0v
+                        :id |oanQQWBwXJ
+                    :id |UeSjmFza_l
+                  |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616066309)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |testing) (:id |TNtpTuXTCu)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616096690) (:text "|\"pick-type fail a") (:id |L4AKvHICHQ)
+                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616066309)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |is) (:id |7N69tfSSG1)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616066309)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |=ok) (:id |XdEgoyJxiM)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |false) (:id |e1sNtSnfOg)
+                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616066309)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |validate-lilac) (:id |XempUaNYDg)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616066309)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |{}) (:id |SvoP-IhfOz)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616066309)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |:type) (:id |7vHx0x_xqb)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |:a) (:id |0eG884aa4F)
+                                        :id |ci7cSyVnaZ
+                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616066309)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |:name) (:id |pXMQcdaZpWe)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |1) (:id |0J2csxawJEa)
+                                        :id |HxnG7kEjDy8
+                                    :id |w2tB1CNibb
+                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616066309) (:text |a-or-b) (:id |DtIFHTS7Xea)
+                                :id |aHw8fZvadw
+                            :id |MWL90apOYJ
+                        :id |cb2mUdXS7V
+                    :id |7bI0-X4Jy1
+                  |n $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615816330)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615836811) (:text |testing) (:id |4kVWDqnDO)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616369507) (:text "|\"pick-type of unknown c") (:id |bIQD9mLv8d)
+                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615851714)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |is) (:id |kUJVUuAkfp)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615851714)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |=ok) (:id |xc-kwIfaXg)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616391450) (:text |false) (:id |WdEV3mRaM4)
+                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615851714)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615851714) (:text |validate-lilac) (:id |DrgbxyRkPM)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615856809)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615857162) (:text |{}) (:id |t0udBfmoPX)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600615857487)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600615862108) (:text |:type) (:id |TiFVRm8t6a)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616374684) (:text |:c) (:id |-T6-aiKT7K)
+                                        :id |3tvj2eKbVC
+                                    :id |zXEIEPwG2S
+                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616012768) (:text |a-or-b) (:id |HGSBH3TDDH)
+                                :id |vhgCXEwNsp
+                            :id |ckNRzsfA_s
+                        :id |EXOQeBlAIq
+                    :id |5slPoTccV
+                :id |59MmaMXwK
+              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616461529)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616463047) (:text |testing) (:id |zB2h3JQZ6Nleaf)
+                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616474681) (:text "|\"pick-type with custom field") (:id |70IM0kP8B)
+                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616476546)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616476822) (:text |is) (:id |3PwXUJUhS)
+                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616478617)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616479077) (:text |=ok) (:id |-jpy7YDuW)
+                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616480283) (:text |true) (:id |vNis8_FAp_)
+                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616488312)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616488312) (:text |validate-lilac) (:id |M0WQlOZ_6p)
+                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616488312)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616488312) (:text |{}) (:id |njJ5Kv1TDI)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616488312)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616495600) (:text |:branch) (:id |YuonC55Nea)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616521083) (:text |:a) (:id |kinhqedGEe)
+                                    :id |k6rpFxHEdP
+                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616488312)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616488312) (:text |:name) (:id |oPHjl0rInR)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616488312) (:text "|\"a") (:id |MveNoXiuRS)
+                                    :id |wP6z0F87fb
+                                :id |zhzY3FkfFO
+                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |pick-type+) (:id |wgsdJa_1wZ)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |{}) (:id |k3GKkAitMh)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |:a) (:id |jziGpAOelK)
+                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |record+) (:id |98ickr7s1C)
+                                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |{}) (:id |I0i8Zd7h5w)
+                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616604233) (:text |:branch) (:id |SpsZEsdX9J)
+                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |is+) (:id |zanxLXpM8p)
+                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |:a) (:id |gb_4G-H1k2q)
+                                                        :id |NfyS9Z3lgj
+                                                    :id |fuh0RIJF0m
+                                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |:name) (:id |725DY10EdSt)
+                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |string+) (:id |tYdSv05p4Qk)
+                                                        :id |58BwBaTuD27
+                                                    :id |xwgVdf1-CtF
+                                                :id |GbNpsfsQqv
+                                            :id |Cd_h1aERac
+                                        :id |p0gLgoWRuP
+                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |:b) (:id |o8OYgN5Jg-U)
+                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |record+) (:id |beFPtiT0DPP)
+                                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |{}) (:id |cU_L4D4DNbJ)
+                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616608682) (:text |:branch) (:id |D8789S-y632)
+                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |is+) (:id |vZ3cdyIPVAU)
+                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |:b) (:id |Yn3fdQtW9nb)
+                                                        :id |E9rAQRUnBnU
+                                                    :id |fkkWA0XEF2P
+                                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |:size) (:id |BHOZSd-EQUd)
+                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616501339)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616501339) (:text |number+) (:id |Wat2DYmObgo)
+                                                        :id |Niup-tANI24
+                                                    :id |BhOBdrWmkwi
+                                                :id |9IRMXaZke85
+                                            :id |O3NjXAd-SBK
+                                        :id |NuE2diYxsH2
+                                    :id |Me7HnqsgXm
+                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616503482)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616503954) (:text |{}) (:id |Sw_vEzqtzUleaf)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1600616504234)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616509596) (:text |:type-field) (:id |zvmDlGnlK)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1600616512167) (:text |:branch) (:id |BtuH3Jqup)
+                                        :id |moWtaA48yg
+                                    :id |Sw_vEzqtzU
+                                :id |2FHxeajLmA
+                            :id |arueLnh5qb
+                        :id |kIGGjwwDEK
+                    :id |pFuoUkr1Kl
+                :id |zB2h3JQZ6N
+            :id |bbwonXdGtj
           |test-optional-record $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1581956149765)
             :data $ {}
               |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1581956162873) (:text |deftest) (:id |GWwCAKywc)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "jiyinyiyong <jiyinyiyong@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "shadow-cljs": "^2.10.17",
+    "shadow-cljs": "^2.11.3",
     "source-map-support": "^0.5.19",
     "ws": "^7.3.1"
   }

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.1.6",
+{:version "0.1.7-a1",
  :group-id "mvc-works",
  :artifact-id "lilac",
  :skip-tag true,

--- a/src/lilac/test.cljs
+++ b/src/lilac/test.cljs
@@ -24,6 +24,7 @@
               nil+
               or+
               is+
+              pick-type+
               register-custom-rule!]]
             [lilac.router :refer [lilac-router+ router-data]]))
 
@@ -195,6 +196,30 @@
  (testing
   "keyword is not number or string"
   (is (=ok false (validate-lilac :x (or+ [(number+) (string+)]))))))
+
+(deftest
+ test-pick-type
+ (let [a-or-b (pick-type+
+               {:a (record+ {:type (is+ :a), :name (string+)}),
+                :b (record+ {:type (is+ :b), :size (number+)})})]
+   (testing "pick-type of a" (is (=ok true (validate-lilac {:type :a, :name "a"} a-or-b))))
+   (testing "pick-type of b" (is (=ok true (validate-lilac {:type :b, :size 1} a-or-b))))
+   (testing "pick-type of unknown c" (is (=ok false (validate-lilac {:type :c} a-or-b))))
+   (testing
+    "pick-type fail b"
+    (is (=ok false (validate-lilac {:type :b, :name "a"} a-or-b))))
+   (testing "pick-type fail a" (is (=ok false (validate-lilac {:type :a, :name 1} a-or-b)))))
+ (testing
+  "pick-type with custom field"
+  (is
+   (=ok
+    true
+    (validate-lilac
+     {:branch :a, :name "a"}
+     (pick-type+
+      {:a (record+ {:branch (is+ :a), :name (string+)}),
+       :b (record+ {:branch (is+ :b), :size (number+)})}
+      {:type-field :branch}))))))
 
 (deftest
  test-record

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,15 @@
 # yarn lockfile v1
 
 
-asn1.js@^4.0.0:
-  version "4.10.1"
-  resolved "https://registry.npm.taobao.org/asn1.js/download/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
-  integrity sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=
+asn1.js@^5.2.0:
+  version "5.4.1"
+  resolved "https://registry.npm.taobao.org/asn1.js/download/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
+  integrity sha1-EamAuE67kXgc41sP3C7ilON4Pwc=
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
+    safer-buffer "^2.1.0"
 
 assert@^1.1.1:
   version "1.5.0"
@@ -21,7 +22,7 @@ assert@^1.1.1:
 
 async-limiter@~1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/async-limiter/download/async-limiter-1.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fasync-limiter%2Fdownload%2Fasync-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  resolved "https://registry.npm.taobao.org/async-limiter/download/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=
 
 base64-js@^1.0.2:
@@ -35,9 +36,9 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   integrity sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=
 
 bn.js@^5.1.1:
-  version "5.1.2"
-  resolved "https://registry.npm.taobao.org/bn.js/download/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
-  integrity sha1-yWhpAtPJoncp9DqxD515wgBNp7A=
+  version "5.1.3"
+  resolved "https://registry.npm.taobao.org/bn.js/download/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
+  integrity sha1-vsoAVAj2Quvr6oCwQrTRjSrA7ms=
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -84,15 +85,15 @@ browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
     randombytes "^2.0.1"
 
 browserify-sign@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.npm.taobao.org/browserify-sign/download/browserify-sign-4.2.0.tgz?cache=0&sync_timestamp=1589815351575&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbrowserify-sign%2Fdownload%2Fbrowserify-sign-4.2.0.tgz#545d0b1b07e6b2c99211082bf1b12cce7a0b0e11"
-  integrity sha1-VF0LGwfmssmSEQgr8bEsznoLDhE=
+  version "4.2.1"
+  resolved "https://registry.npm.taobao.org/browserify-sign/download/browserify-sign-4.2.1.tgz?cache=0&sync_timestamp=1596557797092&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbrowserify-sign%2Fdownload%2Fbrowserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3"
+  integrity sha1-6vSt1G3VS+O7OzbAzxWrvrp5VsM=
   dependencies:
     bn.js "^5.1.1"
     browserify-rsa "^4.0.1"
     create-hash "^1.2.0"
     create-hmac "^1.1.7"
-    elliptic "^6.5.2"
+    elliptic "^6.5.3"
     inherits "^2.0.4"
     parse-asn1 "^5.1.5"
     readable-stream "^3.6.0"
@@ -153,12 +154,12 @@ core-util-is@~1.0.0:
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 create-ecdh@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.npm.taobao.org/create-ecdh/download/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
-  integrity sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=
+  version "4.0.4"
+  resolved "https://registry.npm.taobao.org/create-ecdh/download/create-ecdh-4.0.4.tgz?cache=0&sync_timestamp=1596557796546&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcreate-ecdh%2Fdownload%2Fcreate-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
+  integrity sha1-1uf0v/pmc2CFoHYv06YyaE2rzE4=
   dependencies:
     bn.js "^4.1.0"
-    elliptic "^6.0.0"
+    elliptic "^6.5.3"
 
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
@@ -219,12 +220,12 @@ diffie-hellman@^5.0.0:
 
 domain-browser@^1.1.1:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/domain-browser/download/domain-browser-1.2.0.tgz?cache=0&sync_timestamp=1595352528594&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomain-browser%2Fdownload%2Fdomain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+  resolved "https://registry.npm.taobao.org/domain-browser/download/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=
 
-elliptic@^6.0.0, elliptic@^6.5.2:
+elliptic@^6.5.3:
   version "6.5.3"
-  resolved "https://registry.npm.taobao.org/elliptic/download/elliptic-6.5.3.tgz?cache=0&sync_timestamp=1592495124800&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Felliptic%2Fdownload%2Felliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  resolved "https://registry.npm.taobao.org/elliptic/download/elliptic-6.5.3.tgz?cache=0&sync_timestamp=1592492734974&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Felliptic%2Fdownload%2Felliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=
   dependencies:
     bn.js "^4.4.0"
@@ -237,7 +238,7 @@ elliptic@^6.0.0, elliptic@^6.5.2:
 
 events@^3.0.0:
   version "3.2.0"
-  resolved "https://registry.npm.taobao.org/events/download/events-3.2.0.tgz?cache=0&sync_timestamp=1595422555438&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fevents%2Fdownload%2Fevents-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
+  resolved "https://registry.npm.taobao.org/events/download/events-3.2.0.tgz?cache=0&sync_timestamp=1595422651095&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fevents%2Fdownload%2Fevents-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha1-k7h8GPjvzUICpGGuxN/AVWtjk3k=
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
@@ -250,7 +251,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
 
 hash-base@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.npm.taobao.org/hash-base/download/hash-base-3.1.0.tgz?cache=0&sync_timestamp=1588318030847&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhash-base%2Fdownload%2Fhash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  resolved "https://registry.npm.taobao.org/hash-base/download/hash-base-3.1.0.tgz?cache=0&sync_timestamp=1588318012719&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhash-base%2Fdownload%2Fhash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
   integrity sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=
   dependencies:
     inherits "^2.0.4"
@@ -306,7 +307,7 @@ isarray@^1.0.0, isarray@~1.0.0:
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npm.taobao.org/isexe/download/isexe-2.0.0.tgz?cache=0&sync_timestamp=1589903651068&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fisexe%2Fdownload%2Fisexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.npm.taobao.org/isexe/download/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 md5.js@^1.3.4:
@@ -336,7 +337,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npm.taobao.org/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-node-libs-browser@^2.0.0:
+node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
   integrity sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=
@@ -367,7 +368,7 @@ node-libs-browser@^2.0.0:
 
 object-assign@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  resolved "https://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fobject-assign%2Fdownload%2Fobject-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 os-browserify@^0.3.0:
@@ -381,20 +382,19 @@ pako@~1.0.5:
   integrity sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=
 
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.npm.taobao.org/parse-asn1/download/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
-  integrity sha1-ADJxND2ljclMrOSU+u89IUfs6g4=
+  version "5.1.6"
+  resolved "https://registry.npm.taobao.org/parse-asn1/download/parse-asn1-5.1.6.tgz?cache=0&sync_timestamp=1597166016316&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse-asn1%2Fdownload%2Fparse-asn1-5.1.6.tgz#385080a3ec13cb62a62d39409cb3e88844cdaed4"
+  integrity sha1-OFCAo+wTy2KmLTlAnLPoiETNrtQ=
   dependencies:
-    asn1.js "^4.0.0"
+    asn1.js "^5.2.0"
     browserify-aes "^1.0.0"
-    create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
 path-browserify@0.0.1:
   version "0.0.1"
-  resolved "https://registry.npm.taobao.org/path-browserify/download/path-browserify-0.0.1.tgz?cache=0&sync_timestamp=1583254392335&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpath-browserify%2Fdownload%2Fpath-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
+  resolved "https://registry.npm.taobao.org/path-browserify/download/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
   integrity sha1-5sTd1+06onxoogzE5Q4aTug7vEo=
 
 pbkdf2@^3.0.3:
@@ -467,7 +467,7 @@ randomfill@^1.0.3:
 
 readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.7"
-  resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.7.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=
   dependencies:
     core-util-is "~1.0.0"
@@ -480,7 +480,7 @@ readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
 
 readable-stream@^3.6.0:
   version "3.6.0"
-  resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-3.6.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha1-M3u9o63AcGvT4CRCaihtS0sskZg=
   dependencies:
     inherits "^2.0.3"
@@ -502,13 +502,18 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
-  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.2.1.tgz?cache=0&sync_timestamp=1589129611964&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsafe-buffer%2Fdownload%2Fsafe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
-  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz?cache=0&sync_timestamp=1589129611964&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsafe-buffer%2Fdownload%2Fsafe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha1-mR7GnSluAxN0fVm9/St0XDX4go0=
+
+safer-buffer@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.npm.taobao.org/safer-buffer/download/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=
 
 setimmediate@^1.0.4:
   version "1.0.5"
@@ -528,12 +533,12 @@ shadow-cljs-jar@1.3.2:
   resolved "https://registry.npm.taobao.org/shadow-cljs-jar/download/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
   integrity sha1-lyc6/hdHtqIxGRfByI2eJDyBlXs=
 
-shadow-cljs@^2.10.17:
-  version "2.10.17"
-  resolved "https://registry.npm.taobao.org/shadow-cljs/download/shadow-cljs-2.10.17.tgz#490aea50f95481bb40936d79bade3aa62033dca3"
-  integrity sha1-SQrqUPlUgbtAk215ut46piAz3KM=
+shadow-cljs@^2.11.3:
+  version "2.11.3"
+  resolved "https://registry.npm.taobao.org/shadow-cljs/download/shadow-cljs-2.11.3.tgz#77a86de8a240dd0c6a869078002ed5f5c96a9b84"
+  integrity sha1-d6ht6KJA3QxqhpB4AC7V9clqm4Q=
   dependencies:
-    node-libs-browser "^2.0.0"
+    node-libs-browser "^2.2.1"
     readline-sync "^1.4.7"
     shadow-cljs-jar "1.3.2"
     source-map-support "^0.4.15"
@@ -567,7 +572,7 @@ source-map@^0.6.0:
 
 stream-browserify@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.npm.taobao.org/stream-browserify/download/stream-browserify-2.0.2.tgz?cache=0&sync_timestamp=1587041559738&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstream-browserify%2Fdownload%2Fstream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
+  resolved "https://registry.npm.taobao.org/stream-browserify/download/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
   integrity sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=
   dependencies:
     inherits "~2.0.1"
@@ -575,7 +580,7 @@ stream-browserify@^2.0.1:
 
 stream-http@^2.7.2:
   version "2.8.3"
-  resolved "https://registry.npm.taobao.org/stream-http/download/stream-http-2.8.3.tgz?cache=0&sync_timestamp=1588701390104&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstream-http%2Fdownload%2Fstream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
+  resolved "https://registry.npm.taobao.org/stream-http/download/stream-http-2.8.3.tgz?cache=0&sync_timestamp=1588701397289&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstream-http%2Fdownload%2Fstream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
   integrity sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=
   dependencies:
     builtin-status-codes "^3.0.0"
@@ -635,14 +640,14 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
 
 util@0.10.3:
   version "0.10.3"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  resolved "https://registry.npm.taobao.org/util/download/util-0.10.3.tgz?cache=0&sync_timestamp=1588238397004&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil%2Fdownload%2Futil-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
 
 util@^0.11.0:
   version "0.11.1"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  resolved "https://registry.npm.taobao.org/util/download/util-0.11.1.tgz?cache=0&sync_timestamp=1588238397004&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil%2Fdownload%2Futil-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
   integrity sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=
   dependencies:
     inherits "2.0.3"


### PR DESCRIPTION
```clojure
(validate-lilac
 {:branch :a, :name "a"}
 (pick-type+
  {:a (record+ {:branch (is+ :a), :name (string+)}),
   :b (record+ {:branch (is+ :b), :size (number+)})}
  {:type-field :branch}))
```
